### PR TITLE
Saved Tool Layout and CPU-Z SPD tabs

### DIFF
--- a/EhwValidationTool/CpuzLaunchInfo.cs
+++ b/EhwValidationTool/CpuzLaunchInfo.cs
@@ -1,0 +1,32 @@
+﻿namespace EhwValidationTool
+{
+    public class CpuzLaunchInfo : ToolLaunchInfo
+    {
+        public override ToolType ToolType => ToolType.CpuZ;
+        public CpuzTabType TabType
+        {
+            get { return _tabType; }
+            set
+            {
+                _tabType = value;
+                SelectTabIndex = (int)value;
+            }
+        }
+        private CpuzTabType _tabType;
+
+        // 1 based index based on the Slot in the CPU-Z UI
+        public int? SpdSlot { get; set; }
+
+
+        public enum CpuzTabType
+        {
+            CPU = 0,
+            Mainboard = 1,
+            Memory = 2,
+            SPD = 3,
+            Graphics = 4,
+            Bench = 5,
+            About = 6
+        }
+    }
+}

--- a/EhwValidationTool/CpuzSaveInfo.cs
+++ b/EhwValidationTool/CpuzSaveInfo.cs
@@ -1,0 +1,12 @@
+﻿using static EhwValidationTool.CpuzLaunchInfo;
+
+namespace EhwValidationTool
+{
+    public class CpuzSaveInfo : ToolSaveInfo
+    {
+        public override ToolType ToolType => ToolType.CpuZ;
+
+        public CpuzTabType TabType { get; set; }
+        public int? SpdSlot { get; set; }
+    }
+}

--- a/EhwValidationTool/EhwValidationTool.csproj
+++ b/EhwValidationTool/EhwValidationTool.csproj
@@ -109,6 +109,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CpuzSaveInfo.cs" />
     <Compile Include="MainForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -128,7 +129,9 @@
     <Compile Include="CpuzLaunchInfo.cs" />
     <Compile Include="ToolLaunchInfo.cs" />
     <Compile Include="ToolLocation.cs" />
+    <Compile Include="ToolSaveInfo.cs" />
     <Compile Include="ToolType.cs" />
+    <Compile Include="ToolSaveInfoConverter.cs" />
     <Compile Include="UserInfoForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/EhwValidationTool/EhwValidationTool.csproj
+++ b/EhwValidationTool/EhwValidationTool.csproj
@@ -125,6 +125,7 @@
       <DependentUpon>SettingsForm.cs</DependentUpon>
     </Compile>
     <Compile Include="ToolLauncher.cs" />
+    <Compile Include="CpuzLaunchInfo.cs" />
     <Compile Include="ToolLaunchInfo.cs" />
     <Compile Include="ToolLocation.cs" />
     <Compile Include="ToolType.cs" />

--- a/EhwValidationTool/MainForm.Designer.cs
+++ b/EhwValidationTool/MainForm.Designer.cs
@@ -43,6 +43,8 @@
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.chkShowSpdTabsSlot12 = new System.Windows.Forms.CheckBox();
             this.chkShowSpdTabsSlot24 = new System.Windows.Forms.CheckBox();
+            this.btnSaveLayout = new System.Windows.Forms.Button();
+            this.btnLaunchSavedLayout = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // btn3dLeft
@@ -108,7 +110,7 @@
             // btnCloseTools
             // 
             this.btnCloseTools.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnCloseTools.Location = new System.Drawing.Point(246, 211);
+            this.btnCloseTools.Location = new System.Drawing.Point(246, 276);
             this.btnCloseTools.Name = "btnCloseTools";
             this.btnCloseTools.Size = new System.Drawing.Size(180, 23);
             this.btnCloseTools.TabIndex = 6;
@@ -119,7 +121,7 @@
             // btnTakeScreenshot
             // 
             this.btnTakeScreenshot.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.btnTakeScreenshot.Location = new System.Drawing.Point(15, 211);
+            this.btnTakeScreenshot.Location = new System.Drawing.Point(15, 276);
             this.btnTakeScreenshot.Name = "btnTakeScreenshot";
             this.btnTakeScreenshot.Size = new System.Drawing.Size(180, 23);
             this.btnTakeScreenshot.TabIndex = 7;
@@ -171,11 +173,33 @@
             this.chkShowSpdTabsSlot24.UseVisualStyleBackColor = true;
             this.chkShowSpdTabsSlot24.CheckedChanged += new System.EventHandler(this.chkShowSpdTabs_CheckedChanged);
             // 
+            // btnSaveLayout
+            // 
+            this.btnSaveLayout.Location = new System.Drawing.Point(246, 221);
+            this.btnSaveLayout.Name = "btnSaveLayout";
+            this.btnSaveLayout.Size = new System.Drawing.Size(180, 23);
+            this.btnSaveLayout.TabIndex = 13;
+            this.btnSaveLayout.Text = "Save Current Layout";
+            this.btnSaveLayout.UseVisualStyleBackColor = true;
+            this.btnSaveLayout.Click += new System.EventHandler(this.btnSaveLayout_Click);
+            // 
+            // btnLaunchSavedLayout
+            // 
+            this.btnLaunchSavedLayout.Location = new System.Drawing.Point(15, 221);
+            this.btnLaunchSavedLayout.Name = "btnLaunchSavedLayout";
+            this.btnLaunchSavedLayout.Size = new System.Drawing.Size(180, 23);
+            this.btnLaunchSavedLayout.TabIndex = 12;
+            this.btnLaunchSavedLayout.Text = "Launch Saved Layout";
+            this.btnLaunchSavedLayout.UseVisualStyleBackColor = true;
+            this.btnLaunchSavedLayout.Click += new System.EventHandler(this.btnLaunchSavedLayout_Click);
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(446, 246);
+            this.ClientSize = new System.Drawing.Size(446, 311);
+            this.Controls.Add(this.btnSaveLayout);
+            this.Controls.Add(this.btnLaunchSavedLayout);
             this.Controls.Add(this.chkShowSpdTabsSlot24);
             this.Controls.Add(this.chkShowSpdTabsSlot12);
             this.Controls.Add(this.chkSlowMode);
@@ -211,6 +235,8 @@
         private System.Windows.Forms.ToolTip toolTip1;
         private System.Windows.Forms.CheckBox chkShowSpdTabsSlot12;
         private System.Windows.Forms.CheckBox chkShowSpdTabsSlot24;
+        private System.Windows.Forms.Button btnSaveLayout;
+        private System.Windows.Forms.Button btnLaunchSavedLayout;
     }
 }
 

--- a/EhwValidationTool/MainForm.Designer.cs
+++ b/EhwValidationTool/MainForm.Designer.cs
@@ -41,6 +41,7 @@
             this.lblVersion = new System.Windows.Forms.Label();
             this.chkSlowMode = new System.Windows.Forms.CheckBox();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.chkShowSpdTabs = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // btn3dLeft
@@ -145,11 +146,23 @@
             this.toolTip1.SetToolTip(this.chkSlowMode, "Opens tools one at a time.  Useful for single core systems");
             this.chkSlowMode.UseVisualStyleBackColor = true;
             // 
+            // chkShowSpdTabs
+            // 
+            this.chkShowSpdTabs.AutoSize = true;
+            this.chkShowSpdTabs.Location = new System.Drawing.Point(246, 89);
+            this.chkShowSpdTabs.Name = "chkShowSpdTabs";
+            this.chkShowSpdTabs.Size = new System.Drawing.Size(166, 17);
+            this.chkShowSpdTabs.TabIndex = 10;
+            this.chkShowSpdTabs.Text = "Show CPU-Z SPD (Slots 1, 2)";
+            this.toolTip1.SetToolTip(this.chkShowSpdTabs, "Opens tools one at a time.  Useful for single core systems");
+            this.chkShowSpdTabs.UseVisualStyleBackColor = true;
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(446, 246);
+            this.Controls.Add(this.chkShowSpdTabs);
             this.Controls.Add(this.chkSlowMode);
             this.Controls.Add(this.lblVersion);
             this.Controls.Add(this.btnTakeScreenshot);
@@ -181,6 +194,7 @@
         private System.Windows.Forms.Label lblVersion;
         private System.Windows.Forms.CheckBox chkSlowMode;
         private System.Windows.Forms.ToolTip toolTip1;
+        private System.Windows.Forms.CheckBox chkShowSpdTabs;
     }
 }
 

--- a/EhwValidationTool/MainForm.Designer.cs
+++ b/EhwValidationTool/MainForm.Designer.cs
@@ -41,12 +41,13 @@
             this.lblVersion = new System.Windows.Forms.Label();
             this.chkSlowMode = new System.Windows.Forms.CheckBox();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.chkShowSpdTabs = new System.Windows.Forms.CheckBox();
+            this.chkShowSpdTabsSlot12 = new System.Windows.Forms.CheckBox();
+            this.chkShowSpdTabsSlot24 = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // btn3dLeft
             // 
-            this.btn3dLeft.Location = new System.Drawing.Point(15, 141);
+            this.btn3dLeft.Location = new System.Drawing.Point(15, 165);
             this.btn3dLeft.Name = "btn3dLeft";
             this.btn3dLeft.Size = new System.Drawing.Size(180, 23);
             this.btn3dLeft.TabIndex = 0;
@@ -57,7 +58,7 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(12, 57);
+            this.label1.Location = new System.Drawing.Point(12, 51);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(313, 13);
             this.label1.TabIndex = 1;
@@ -65,7 +66,7 @@
             // 
             // btn2dLeft
             // 
-            this.btn2dLeft.Location = new System.Drawing.Point(15, 112);
+            this.btn2dLeft.Location = new System.Drawing.Point(15, 136);
             this.btn2dLeft.Name = "btn2dLeft";
             this.btn2dLeft.Size = new System.Drawing.Size(180, 23);
             this.btn2dLeft.TabIndex = 2;
@@ -86,7 +87,7 @@
             // 
             // btn2dRight
             // 
-            this.btn2dRight.Location = new System.Drawing.Point(246, 112);
+            this.btn2dRight.Location = new System.Drawing.Point(246, 136);
             this.btn2dRight.Name = "btn2dRight";
             this.btn2dRight.Size = new System.Drawing.Size(180, 23);
             this.btn2dRight.TabIndex = 5;
@@ -96,7 +97,7 @@
             // 
             // btn3dRight
             // 
-            this.btn3dRight.Location = new System.Drawing.Point(246, 141);
+            this.btn3dRight.Location = new System.Drawing.Point(246, 165);
             this.btn3dRight.Name = "btn3dRight";
             this.btn3dRight.Size = new System.Drawing.Size(180, 23);
             this.btn3dRight.TabIndex = 4;
@@ -138,7 +139,7 @@
             // chkSlowMode
             // 
             this.chkSlowMode.AutoSize = true;
-            this.chkSlowMode.Location = new System.Drawing.Point(15, 89);
+            this.chkSlowMode.Location = new System.Drawing.Point(15, 86);
             this.chkSlowMode.Name = "chkSlowMode";
             this.chkSlowMode.Size = new System.Drawing.Size(79, 17);
             this.chkSlowMode.TabIndex = 9;
@@ -146,23 +147,37 @@
             this.toolTip1.SetToolTip(this.chkSlowMode, "Opens tools one at a time.  Useful for single core systems");
             this.chkSlowMode.UseVisualStyleBackColor = true;
             // 
-            // chkShowSpdTabs
+            // chkShowSpdTabsSlot12
             // 
-            this.chkShowSpdTabs.AutoSize = true;
-            this.chkShowSpdTabs.Location = new System.Drawing.Point(246, 89);
-            this.chkShowSpdTabs.Name = "chkShowSpdTabs";
-            this.chkShowSpdTabs.Size = new System.Drawing.Size(166, 17);
-            this.chkShowSpdTabs.TabIndex = 10;
-            this.chkShowSpdTabs.Text = "Show CPU-Z SPD (Slots 1, 2)";
-            this.toolTip1.SetToolTip(this.chkShowSpdTabs, "Opens tools one at a time.  Useful for single core systems");
-            this.chkShowSpdTabs.UseVisualStyleBackColor = true;
+            this.chkShowSpdTabsSlot12.AutoSize = true;
+            this.chkShowSpdTabsSlot12.Location = new System.Drawing.Point(246, 86);
+            this.chkShowSpdTabsSlot12.Name = "chkShowSpdTabsSlot12";
+            this.chkShowSpdTabsSlot12.Size = new System.Drawing.Size(166, 17);
+            this.chkShowSpdTabsSlot12.TabIndex = 10;
+            this.chkShowSpdTabsSlot12.Text = "Show CPU-Z SPD (Slots 1, 2)";
+            this.toolTip1.SetToolTip(this.chkShowSpdTabsSlot12, "Opens tools one at a time.  Useful for single core systems");
+            this.chkShowSpdTabsSlot12.UseVisualStyleBackColor = true;
+            this.chkShowSpdTabsSlot12.CheckedChanged += new System.EventHandler(this.chkShowSpdTabs_CheckedChanged);
+            // 
+            // chkShowSpdTabsSlot24
+            // 
+            this.chkShowSpdTabsSlot24.AutoSize = true;
+            this.chkShowSpdTabsSlot24.Location = new System.Drawing.Point(246, 108);
+            this.chkShowSpdTabsSlot24.Name = "chkShowSpdTabsSlot24";
+            this.chkShowSpdTabsSlot24.Size = new System.Drawing.Size(166, 17);
+            this.chkShowSpdTabsSlot24.TabIndex = 11;
+            this.chkShowSpdTabsSlot24.Text = "Show CPU-Z SPD (Slots 2, 4)";
+            this.toolTip1.SetToolTip(this.chkShowSpdTabsSlot24, "Opens tools one at a time.  Useful for single core systems");
+            this.chkShowSpdTabsSlot24.UseVisualStyleBackColor = true;
+            this.chkShowSpdTabsSlot24.CheckedChanged += new System.EventHandler(this.chkShowSpdTabs_CheckedChanged);
             // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(446, 246);
-            this.Controls.Add(this.chkShowSpdTabs);
+            this.Controls.Add(this.chkShowSpdTabsSlot24);
+            this.Controls.Add(this.chkShowSpdTabsSlot12);
             this.Controls.Add(this.chkSlowMode);
             this.Controls.Add(this.lblVersion);
             this.Controls.Add(this.btnTakeScreenshot);
@@ -194,7 +209,8 @@
         private System.Windows.Forms.Label lblVersion;
         private System.Windows.Forms.CheckBox chkSlowMode;
         private System.Windows.Forms.ToolTip toolTip1;
-        private System.Windows.Forms.CheckBox chkShowSpdTabs;
+        private System.Windows.Forms.CheckBox chkShowSpdTabsSlot12;
+        private System.Windows.Forms.CheckBox chkShowSpdTabsSlot24;
     }
 }
 

--- a/EhwValidationTool/MainForm.cs
+++ b/EhwValidationTool/MainForm.cs
@@ -35,8 +35,10 @@ namespace EhwValidationTool
             this.chkSlowMode.Checked = Settings.Default.EnableSlowMode;
             this.chkSlowMode.CheckedChanged += chkSlowMode_CheckedChanged;
 
-            this.chkShowSpdTabs.Checked = Settings.Default.EnableSpdTabs;
-            this.chkShowSpdTabs.CheckedChanged += chkShowSpdTabs_CheckedChanged;
+            this.chkShowSpdTabsSlot12.Checked = Settings.Default.EnableSpdTabsSlot1Slot2;
+            this.chkShowSpdTabsSlot24.Checked = Settings.Default.EnableSpdTabsSlot2Slot4;
+            this.chkShowSpdTabsSlot12.CheckedChanged += chkShowSpdTabs_CheckedChanged;
+            this.chkShowSpdTabsSlot24.CheckedChanged += chkShowSpdTabs_CheckedChanged;
         }
 
         public void CloseTools()
@@ -125,6 +127,29 @@ namespace EhwValidationTool
             }
         }
 
+        private List<ToolLaunchInfo> getSpdToToolLaunchInfo(ToolLocation toolLocation)
+        {
+            var tools = new List<ToolLaunchInfo>();
+
+            if (chkShowSpdTabsSlot12.Checked || chkShowSpdTabsSlot24.Checked)
+            {
+                int firstSlot = chkShowSpdTabsSlot12.Checked ? 1 : 2;
+                int secondSlot = chkShowSpdTabsSlot12.Checked ? 2 : 4;
+
+                if(toolLocation == ToolLocation.TopRight || toolLocation == ToolLocation.BottomRight)
+                {
+                    var tmp = firstSlot;
+                    firstSlot = secondSlot;
+                    secondSlot = tmp;
+                }
+
+                tools.Add(new CpuzLaunchInfo { ToolLocation = toolLocation, InstanceNumber = 1, TabType = CpuzLaunchInfo.CpuzTabType.SPD, SpdSlot = firstSlot });
+                tools.Add(new CpuzLaunchInfo { ToolLocation = toolLocation, InstanceNumber = 2, TabType = CpuzLaunchInfo.CpuzTabType.SPD, SpdSlot = secondSlot });
+            }
+
+            return tools;
+        }
+
         private async void btn2dLeft_Click(object sender, EventArgs e)
         {
             if (!ensureToolExists(ToolType.CpuZ))
@@ -136,11 +161,7 @@ namespace EhwValidationTool
                 new CpuzLaunchInfo { ToolLocation = ToolLocation.BottomLeft, InstanceNumber = 2, TabType = CpuzLaunchInfo.CpuzTabType.Mainboard },
                 new CpuzLaunchInfo { ToolLocation = ToolLocation.BottomLeft, InstanceNumber = 3, TabType = CpuzLaunchInfo.CpuzTabType.Memory }
             };
-            if (chkShowSpdTabs.Checked)
-            {
-                tools.Add(new CpuzLaunchInfo { ToolLocation = ToolLocation.TopLeft, InstanceNumber = 1, TabType = CpuzLaunchInfo.CpuzTabType.SPD, SpdSlot = 1 });
-                tools.Add(new CpuzLaunchInfo { ToolLocation = ToolLocation.TopLeft, InstanceNumber = 2, TabType = CpuzLaunchInfo.CpuzTabType.SPD, SpdSlot = 2 });
-            }
+            tools.AddRange(getSpdToToolLaunchInfo(ToolLocation.TopLeft));
 
             var launchedProcesses = await ToolLauncher.LaunchTools(tools, chkSlowMode.Checked);
             processes.AddRange(launchedProcesses);
@@ -176,11 +197,7 @@ namespace EhwValidationTool
                 new CpuzLaunchInfo { ToolLocation = ToolLocation.BottomRight, InstanceNumber = 2, TabType = CpuzLaunchInfo.CpuzTabType.Mainboard },
                 new CpuzLaunchInfo { ToolLocation = ToolLocation.BottomRight, InstanceNumber = 3, TabType = CpuzLaunchInfo.CpuzTabType.CPU }
             };
-            if (chkShowSpdTabs.Checked)
-            {
-                tools.Add(new CpuzLaunchInfo { ToolLocation = ToolLocation.TopRight, InstanceNumber = 1, TabType = CpuzLaunchInfo.CpuzTabType.SPD, SpdSlot = 2 });
-                tools.Add(new CpuzLaunchInfo { ToolLocation = ToolLocation.TopRight, InstanceNumber = 2, TabType = CpuzLaunchInfo.CpuzTabType.SPD, SpdSlot = 1 });
-            }
+            tools.AddRange(getSpdToToolLaunchInfo(ToolLocation.TopRight));
 
             var launchedProcesses = await ToolLauncher.LaunchTools(tools, chkSlowMode.Checked);
             processes.AddRange(launchedProcesses);
@@ -223,7 +240,8 @@ namespace EhwValidationTool
         }
         private void chkShowSpdTabs_CheckedChanged(object sender, EventArgs e)
         {
-            Settings.Default.EnableSpdTabs = chkShowSpdTabs.Checked;
+            Settings.Default.EnableSpdTabsSlot1Slot2 = chkShowSpdTabsSlot12.Checked;
+            Settings.Default.EnableSpdTabsSlot2Slot4 = chkShowSpdTabsSlot24.Checked;
             Settings.SaveSettings();
         }
     }

--- a/EhwValidationTool/MainForm.cs
+++ b/EhwValidationTool/MainForm.cs
@@ -34,6 +34,9 @@ namespace EhwValidationTool
 
             this.chkSlowMode.Checked = Settings.Default.EnableSlowMode;
             this.chkSlowMode.CheckedChanged += chkSlowMode_CheckedChanged;
+
+            this.chkShowSpdTabs.Checked = Settings.Default.EnableSpdTabs;
+            this.chkShowSpdTabs.CheckedChanged += chkShowSpdTabs_CheckedChanged;
         }
 
         public void CloseTools()
@@ -129,10 +132,15 @@ namespace EhwValidationTool
 
             var tools = new List<ToolLaunchInfo>
             {
-                new ToolLaunchInfo { ToolType = ToolType.CpuZ, ToolLocation = ToolLocation.BottomLeft, InstanceNumber = 1, DisplayUserInfoAboveWindow = true, SelectTabIndex = 0 },
-                new ToolLaunchInfo { ToolType = ToolType.CpuZ, ToolLocation = ToolLocation.BottomLeft, InstanceNumber = 2, SelectTabIndex = 1 },
-                new ToolLaunchInfo { ToolType = ToolType.CpuZ, ToolLocation = ToolLocation.BottomLeft, InstanceNumber = 3, SelectTabIndex = 2 }
+                new CpuzLaunchInfo { ToolLocation = ToolLocation.BottomLeft, InstanceNumber = 1, DisplayUserInfoAboveWindow = true, TabType = CpuzLaunchInfo.CpuzTabType.CPU },
+                new CpuzLaunchInfo { ToolLocation = ToolLocation.BottomLeft, InstanceNumber = 2, TabType = CpuzLaunchInfo.CpuzTabType.Mainboard },
+                new CpuzLaunchInfo { ToolLocation = ToolLocation.BottomLeft, InstanceNumber = 3, TabType = CpuzLaunchInfo.CpuzTabType.Memory }
             };
+            if (chkShowSpdTabs.Checked)
+            {
+                tools.Add(new CpuzLaunchInfo { ToolLocation = ToolLocation.TopLeft, InstanceNumber = 1, TabType = CpuzLaunchInfo.CpuzTabType.SPD, SpdSlot = 1 });
+                tools.Add(new CpuzLaunchInfo { ToolLocation = ToolLocation.TopLeft, InstanceNumber = 2, TabType = CpuzLaunchInfo.CpuzTabType.SPD, SpdSlot = 2 });
+            }
 
             var launchedProcesses = await ToolLauncher.LaunchTools(tools, chkSlowMode.Checked);
             processes.AddRange(launchedProcesses);
@@ -147,9 +155,9 @@ namespace EhwValidationTool
 
             var tools = new List<ToolLaunchInfo>
             {
-                new ToolLaunchInfo { ToolType = ToolType.CpuZ, ToolLocation = ToolLocation.BottomLeft, InstanceNumber = 1, DisplayUserInfoAboveWindow = true, SelectTabIndex = 0 },
-                new ToolLaunchInfo { ToolType = ToolType.CpuZ, ToolLocation = ToolLocation.BottomLeft, InstanceNumber = 2, SelectTabIndex = 1 },
-                new ToolLaunchInfo { ToolType = ToolType.CpuZ, ToolLocation = ToolLocation.BottomLeft, InstanceNumber = 3, SelectTabIndex = 2 },
+                new CpuzLaunchInfo { ToolLocation = ToolLocation.BottomLeft, InstanceNumber = 1, DisplayUserInfoAboveWindow = true, TabType = CpuzLaunchInfo.CpuzTabType.CPU },
+                new CpuzLaunchInfo { ToolLocation = ToolLocation.BottomLeft, InstanceNumber = 2, TabType = CpuzLaunchInfo.CpuzTabType.Mainboard },
+                new CpuzLaunchInfo { ToolLocation = ToolLocation.BottomLeft, InstanceNumber = 3, TabType = CpuzLaunchInfo.CpuzTabType.Memory },
                 new ToolLaunchInfo { ToolType = ToolType.GpuZ, ToolLocation = ToolLocation.TopLeft}
             };
 
@@ -164,10 +172,15 @@ namespace EhwValidationTool
 
             var tools = new List<ToolLaunchInfo>
             {
-                new ToolLaunchInfo { ToolType = ToolType.CpuZ, ToolLocation = ToolLocation.BottomRight, InstanceNumber = 1, DisplayUserInfoAboveWindow = true, SelectTabIndex = 2 },
-                new ToolLaunchInfo { ToolType = ToolType.CpuZ, ToolLocation = ToolLocation.BottomRight, InstanceNumber = 2, SelectTabIndex = 1 },
-                new ToolLaunchInfo { ToolType = ToolType.CpuZ, ToolLocation = ToolLocation.BottomRight, InstanceNumber = 3, SelectTabIndex = 0 }
+                new CpuzLaunchInfo { ToolLocation = ToolLocation.BottomRight, InstanceNumber = 1, DisplayUserInfoAboveWindow = true, TabType = CpuzLaunchInfo.CpuzTabType.Memory },
+                new CpuzLaunchInfo { ToolLocation = ToolLocation.BottomRight, InstanceNumber = 2, TabType = CpuzLaunchInfo.CpuzTabType.Mainboard },
+                new CpuzLaunchInfo { ToolLocation = ToolLocation.BottomRight, InstanceNumber = 3, TabType = CpuzLaunchInfo.CpuzTabType.CPU }
             };
+            if (chkShowSpdTabs.Checked)
+            {
+                tools.Add(new CpuzLaunchInfo { ToolLocation = ToolLocation.TopRight, InstanceNumber = 1, TabType = CpuzLaunchInfo.CpuzTabType.SPD, SpdSlot = 2 });
+                tools.Add(new CpuzLaunchInfo { ToolLocation = ToolLocation.TopRight, InstanceNumber = 2, TabType = CpuzLaunchInfo.CpuzTabType.SPD, SpdSlot = 1 });
+            }
 
             var launchedProcesses = await ToolLauncher.LaunchTools(tools, chkSlowMode.Checked);
             processes.AddRange(launchedProcesses);
@@ -182,9 +195,9 @@ namespace EhwValidationTool
 
             var tools = new List<ToolLaunchInfo>
             {
-                new ToolLaunchInfo { ToolType = ToolType.CpuZ, ToolLocation = ToolLocation.BottomRight, InstanceNumber = 1, DisplayUserInfoAboveWindow = true, SelectTabIndex = 2 },
-                new ToolLaunchInfo { ToolType = ToolType.CpuZ, ToolLocation = ToolLocation.BottomRight, InstanceNumber = 2, SelectTabIndex = 1 },
-                new ToolLaunchInfo { ToolType = ToolType.CpuZ, ToolLocation = ToolLocation.BottomRight, InstanceNumber = 3, SelectTabIndex = 0 },
+                new CpuzLaunchInfo { ToolLocation = ToolLocation.BottomRight, InstanceNumber = 1, DisplayUserInfoAboveWindow = true, TabType = CpuzLaunchInfo.CpuzTabType.Memory },
+                new CpuzLaunchInfo { ToolLocation = ToolLocation.BottomRight, InstanceNumber = 2, TabType = CpuzLaunchInfo.CpuzTabType.Mainboard },
+                new CpuzLaunchInfo { ToolLocation = ToolLocation.BottomRight, InstanceNumber = 3, TabType = CpuzLaunchInfo.CpuzTabType.CPU },
                 new ToolLaunchInfo { ToolType = ToolType.GpuZ, ToolLocation = ToolLocation.TopRight }
             };
 
@@ -206,6 +219,11 @@ namespace EhwValidationTool
         private void chkSlowMode_CheckedChanged(object sender, EventArgs e)
         {
             Settings.Default.EnableSlowMode = chkSlowMode.Checked;
+            Settings.SaveSettings();
+        }
+        private void chkShowSpdTabs_CheckedChanged(object sender, EventArgs e)
+        {
+            Settings.Default.EnableSpdTabs = chkShowSpdTabs.Checked;
             Settings.SaveSettings();
         }
     }

--- a/EhwValidationTool/Properties/AssemblyInfo.cs
+++ b/EhwValidationTool/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.6.0")]
-[assembly: AssemblyFileVersion("0.2.6.0")]
+[assembly: AssemblyVersion("0.2.7.0")]
+[assembly: AssemblyFileVersion("0.2.7.0")]

--- a/EhwValidationTool/Settings.cs
+++ b/EhwValidationTool/Settings.cs
@@ -1,4 +1,6 @@
 ﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 
 namespace EhwValidationTool
@@ -33,6 +35,10 @@ namespace EhwValidationTool
         public bool EnableSlowMode { get;set; }
         public bool EnableSpdTabsSlot1Slot2 { get; set; }
         public bool EnableSpdTabsSlot2Slot4 { get; set; }
+
+        public int UserInfoZOrder { get; set; }
+        public Rectangle UserInfoSavedLayout { get; set; }
+        public List<ToolSaveInfo> SavedLayout { get; set; }
 
         public bool Validate()
         {

--- a/EhwValidationTool/Settings.cs
+++ b/EhwValidationTool/Settings.cs
@@ -31,7 +31,8 @@ namespace EhwValidationTool
         public string HwbotUserName { get; set; }
         public string HwbotTeamName { get; set; }
         public bool EnableSlowMode { get;set; }
-        public bool EnableSpdTabs { get; set; }
+        public bool EnableSpdTabsSlot1Slot2 { get; set; }
+        public bool EnableSpdTabsSlot2Slot4 { get; set; }
 
         public bool Validate()
         {

--- a/EhwValidationTool/Settings.cs
+++ b/EhwValidationTool/Settings.cs
@@ -31,6 +31,7 @@ namespace EhwValidationTool
         public string HwbotUserName { get; set; }
         public string HwbotTeamName { get; set; }
         public bool EnableSlowMode { get;set; }
+        public bool EnableSpdTabs { get; set; }
 
         public bool Validate()
         {

--- a/EhwValidationTool/ToolLaunchInfo.cs
+++ b/EhwValidationTool/ToolLaunchInfo.cs
@@ -1,4 +1,7 @@
-﻿namespace EhwValidationTool
+﻿using System.Diagnostics;
+using System.Drawing;
+
+namespace EhwValidationTool
 {
     public class ToolLaunchInfo
     {
@@ -7,5 +10,13 @@
         public int InstanceNumber { get; set; } = 1;
         public bool DisplayUserInfoAboveWindow { get; set; } = false;
         public int? SelectTabIndex { get; set; }
+
+        public bool IsCustomLayout { get; set; }
+        public Rectangle Location { get; set; }
+        public int ZOrder { get; set; }
+
+
+        // When the tool is launched, the ProcessId will be set
+        public Process Process { get; set; }
     }
 }

--- a/EhwValidationTool/ToolLaunchInfo.cs
+++ b/EhwValidationTool/ToolLaunchInfo.cs
@@ -2,7 +2,7 @@
 {
     public class ToolLaunchInfo
     {
-        public ToolType ToolType { get; set; }
+        public virtual ToolType ToolType { get; set; }
         public ToolLocation ToolLocation { get; set; }
         public int InstanceNumber { get; set; } = 1;
         public bool DisplayUserInfoAboveWindow { get; set; } = false;

--- a/EhwValidationTool/ToolLauncher.cs
+++ b/EhwValidationTool/ToolLauncher.cs
@@ -4,153 +4,196 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft;
+using System.Drawing;
 
 namespace EhwValidationTool
 {
 
     public static class ToolLauncher
     {
-        public static async Task<List<Process>> LaunchTools(List<ToolLaunchInfo> toolList, bool slowMode)
+        private static List<ToolLaunchInfo> _openTools = new List<ToolLaunchInfo>();
+
+
+        public static bool HasOpenTools => _openTools.Any(x=>x.Process?.HasExited == false);
+
+
+        /// <summary>
+        /// Launches the tools and updates the launch info for each tool to specify the tools processid.
+        /// </summary>
+        /// <param name="toolList"></param>
+        /// <param name="slowMode"></param>
+        public static async Task LaunchTools(List<ToolLaunchInfo> toolList, bool slowMode)
         {
+            CloseTools();
+            _openTools = toolList;
+
             if (slowMode)
             {
-                var tasks = new List<Process>();
-                foreach(ToolLaunchInfo launchInfo in toolList)
+                foreach(ToolLaunchInfo launchInfo in toolList.OrderByDescending(x=>x.ZOrder))
                 {
-                    var process = await Launch(launchInfo);
-                    tasks.Add(process);
+                    await Launch(launchInfo);
                 }
-                return tasks;
             }
             else
             {
-                return await TaskEx.Run(() =>
+                await TaskEx.Run(() =>
                 {
-                    var tasks = new List<Task<Process>>();
-                    foreach (var launchInfo in toolList)
+                    var tasks = new List<Task>();
+                    foreach (var launchInfo in toolList.OrderByDescending(x => x.ZOrder))
                     {
                         tasks.Add(Launch(launchInfo));
 
                     }
                     Task.WaitAll(tasks.ToArray());
-                    return tasks.Select(x => x.Result).ToList();
                 });
             }
         }
 
-        public static async Task<Process> Launch(ToolLaunchInfo launchInfo)
+        public static void CloseTools()
+        {
+            _openTools.ForEach(x =>
+            {
+                var process = x.Process;
+                if (process != null)
+                {
+                    if (!process.HasExited)
+                    {
+                        process.Kill();
+                    }
+                }
+            });
+            _openTools.Clear();
+        }
+
+        public static IntPtr GetMainWindowFromProcessId(ToolLaunchInfo launchInfo, int processId)
+        {
+            var windows = Win32Interop.GetRootWindowsOfProcess(processId);
+
+            foreach (var window in windows)
+            {
+                var windowText = Win32Interop.GetWindowText(window);
+                if (isMainToolWindow(launchInfo.ToolType, windowText))
+                    return window;
+            }
+
+            return IntPtr.Zero;
+        }
+
+        private static async Task Launch(ToolLaunchInfo launchInfo)
         {
             var toolPath = GetToolPath(launchInfo.ToolType);
 
             var process = Process.Start(toolPath);
+            launchInfo.Process = process;
 
             bool loop = true;
             while (loop)
             {
                 await TaskEx.Delay(250);
 
-                var windows = Win32Interop.GetRootWindowsOfProcess(process.Id);
+                var window = GetMainWindowFromProcessId(launchInfo, process.Id);
+                if (window == IntPtr.Zero)
+                    continue;
 
-                //Console.WriteLine($"[{DateTime.Now}] {toolType} ({process.Id})");
-                foreach (var window in windows)
+                var rect = new Win32Interop.RECT();
+                Win32Interop.GetWindowRect(window, out rect);
+                var width = rect.right - rect.left;
+                var height = rect.bottom - rect.top;
+
+                int x = 0, y = 0, userInfoLeft = 0, userInfoTop = 0;
+                if (launchInfo.IsCustomLayout)
                 {
-                    var windowText = Win32Interop.GetWindowText(window);
-                    if(!isMainToolWindow(launchInfo.ToolType, windowText))
-                        continue;
-
-                    var rect = new Win32Interop.RECT();
-                    Win32Interop.GetWindowRect(window, out rect);
-                    var width = rect.right - rect.left;
-                    var height = rect.bottom - rect.top;
-                    
-                    int x = 0, y = 0, userInfoLeft = 0, userInfoTop = 0;
-                    if(launchInfo.ToolLocation == ToolLocation.TopLeft)
-                    {
-                        x = width * (launchInfo.InstanceNumber - 1);
-                        y = 0;
-
-                        if (launchInfo.DisplayUserInfoAboveWindow)
-                        {
-                            userInfoLeft = x;
-                            userInfoTop = height;
-                        }
-                    }
-                    else if(launchInfo.ToolLocation == ToolLocation.TopRight)
-                    {
-                        x = Screen.PrimaryScreen.WorkingArea.Width - (width * launchInfo.InstanceNumber);
-                        y = 0;
-
-                        if (launchInfo.DisplayUserInfoAboveWindow)
-                        {
-                            userInfoLeft = x;
-                            userInfoTop = height;
-                        }
-                    }
-                    else if(launchInfo.ToolLocation == ToolLocation.BottomLeft)
-                    {
-                        x = width * (launchInfo.InstanceNumber - 1);
-                        y = Screen.PrimaryScreen.WorkingArea.Height - height;
-
-                        if (launchInfo.DisplayUserInfoAboveWindow)
-                        {
-                            userInfoLeft = x;
-                            userInfoTop = y - MainForm.Instance.GetUserInfoFormHeight();
-                        }
-                    }
-                    else if(launchInfo.ToolLocation == ToolLocation.BottomRight)
-                    {
-                        x = Screen.PrimaryScreen.WorkingArea.Width - (width * launchInfo.InstanceNumber);
-                        y = Screen.PrimaryScreen.WorkingArea.Height - height;
-
-                        if (launchInfo.DisplayUserInfoAboveWindow)
-                        {
-                            userInfoLeft = x;
-                            userInfoTop = y - MainForm.Instance.GetUserInfoFormHeight();
-                        }
-                    }
+                    x = launchInfo.Location.X;
+                    y = launchInfo.Location.Y;
+                    width = launchInfo.Location.Width;
+                    height = launchInfo.Location.Height;
+                }
+                else if(launchInfo.ToolLocation == ToolLocation.TopLeft)
+                {
+                    x = width * (launchInfo.InstanceNumber - 1);
+                    y = 0;
 
                     if (launchInfo.DisplayUserInfoAboveWindow)
                     {
-                        MainForm.Instance.ShowUserInfoForm(userInfoLeft, userInfoTop, width);
+                        userInfoLeft = x;
+                        userInfoTop = height;
                     }
+                }
+                else if(launchInfo.ToolLocation == ToolLocation.TopRight)
+                {
+                    x = Screen.PrimaryScreen.WorkingArea.Width - (width * launchInfo.InstanceNumber);
+                    y = 0;
 
-                    for(int i = 0; i < 100; i++)
+                    if (launchInfo.DisplayUserInfoAboveWindow)
                     {
-                        var moved = Win32Interop.MoveWindow(window, x, y, width, height, true);
-                        await TaskEx.Delay(500);
-
-
-                        Win32Interop.GetWindowRect(window, out rect);
-                        if (rect.left == x && rect.top == y)
-                            break;
+                        userInfoLeft = x;
+                        userInfoTop = height;
                     }
+                }
+                else if(launchInfo.ToolLocation == ToolLocation.BottomLeft)
+                {
+                    x = width * (launchInfo.InstanceNumber - 1);
+                    y = Screen.PrimaryScreen.WorkingArea.Height - height;
 
-                    //Console.WriteLine($"[{DateTime.Now}] {toolType} ({process.Id}) Moved: {moved}");
-
-                    // select the specified tab
-                    if(launchInfo.SelectTabIndex != null)
+                    if (launchInfo.DisplayUserInfoAboveWindow)
                     {
-                        var tabHandle = Win32Interop.GetFirstTabControl(window);
-                        if (tabHandle != IntPtr.Zero)
+                        userInfoLeft = x;
+                        userInfoTop = y - MainForm.Instance.GetUserInfoFormHeight();
+                    }
+                }
+                else if(launchInfo.ToolLocation == ToolLocation.BottomRight)
+                {
+                    x = Screen.PrimaryScreen.WorkingArea.Width - (width * launchInfo.InstanceNumber);
+                    y = Screen.PrimaryScreen.WorkingArea.Height - height;
+
+                    if (launchInfo.DisplayUserInfoAboveWindow)
+                    {
+                        userInfoLeft = x;
+                        userInfoTop = y - MainForm.Instance.GetUserInfoFormHeight();
+                    }
+                }
+
+                if (launchInfo.DisplayUserInfoAboveWindow)
+                {
+                    MainForm.Instance.ShowUserInfoForm(userInfoLeft, userInfoTop, width);
+                }
+
+                for(int i = 0; i < 100; i++)
+                {
+                    var moved = Win32Interop.MoveWindow(window, x, y, width, height, true);
+                    await TaskEx.Delay(500);
+
+
+                    Win32Interop.GetWindowRect(window, out rect);
+                    if (rect.left == x && rect.top == y)
+                        break;
+                }
+
+                //Console.WriteLine($"[{DateTime.Now}] {toolType} ({process.Id}) Moved: {moved}");
+
+                // select the specified tab
+                if(launchInfo.SelectTabIndex != null)
+                {
+                    var tabHandle = Win32Interop.GetFirstTabControl(window);
+                    if (tabHandle != IntPtr.Zero)
+                    {
+                        Win32Interop.SelectTabByIndex(tabHandle, launchInfo.SelectTabIndex.Value);
+
+                        var cpuzLaunchInfo = launchInfo as CpuzLaunchInfo;
+                        if (cpuzLaunchInfo != null && cpuzLaunchInfo.TabType == CpuzLaunchInfo.CpuzTabType.SPD && cpuzLaunchInfo.SpdSlot.HasValue)
                         {
-                            Win32Interop.SelectTabByIndex(tabHandle, launchInfo.SelectTabIndex.Value);
-
-                            var cpuzLaunchInfo = launchInfo as CpuzLaunchInfo;
-                            if (cpuzLaunchInfo != null && cpuzLaunchInfo.TabType == CpuzLaunchInfo.CpuzTabType.SPD && cpuzLaunchInfo.SpdSlot.HasValue)
-                            {
-                                var tabPageHwnd = Win32Interop.GetTabHwndByIndex(tabHandle, launchInfo.SelectTabIndex.Value);
-                                var comboboxHwnd = Win32Interop.GetFirstComboBoxControl(tabPageHwnd);
-                                Win32Interop.SelectComboBoxValueByIndex(comboboxHwnd, cpuzLaunchInfo.SpdSlot.Value-1);
-                            }
+                            var tabPageHwnd = Win32Interop.GetTabHwndByIndex(tabHandle, launchInfo.SelectTabIndex.Value);
+                            var comboboxHwnd = Win32Interop.GetFirstComboBoxControl(tabPageHwnd);
+                            Win32Interop.SelectComboBoxValueByIndex(comboboxHwnd, cpuzLaunchInfo.SpdSlot.Value-1);
                         }
                     }
-
-                    loop = false;
-                    break;
                 }
+
+                loop = false;
             }
 
-            return process;
+            return;
         }
 
         private static bool isMainToolWindow(ToolType toolType, string windowText)
@@ -184,6 +227,28 @@ namespace EhwValidationTool
             }
         }
 
+        private static ToolSaveInfo createSaveInfo(ToolLaunchInfo tool, Rectangle location, int zOrder)
+        {
+            if(tool.ToolType == ToolType.CpuZ)
+            {
+                var cpuzInfo = (CpuzLaunchInfo)tool;
+                return new CpuzSaveInfo
+                {
+                    Location = location,
+                    ZOrder = zOrder,
+                    TabType = cpuzInfo.TabType,
+                    SpdSlot = cpuzInfo.SpdSlot
+                };
+            }
+
+            return new ToolSaveInfo
+            {
+                ToolType = tool.ToolType,
+                Location = location,
+                ZOrder = zOrder
+            };
+        }
+
         public static string GetToolPath(ToolType toolType)
         {
             switch (toolType)
@@ -192,6 +257,63 @@ namespace EhwValidationTool
                 case ToolType.GpuZ: return Settings.Default.GpuzLocation;
                 default: return null;
             }
+        }
+
+
+        public static List<ToolSaveInfo> GetSaveInfoForTools()
+        {
+            var saveInfo = new List<ToolSaveInfo>();
+
+            foreach (var tool in _openTools)
+            {
+                if(tool.Process == null || tool.Process.HasExited)
+                    continue;
+
+                var hwnd = GetMainWindowFromProcessId(tool, tool.Process.Id);
+                var rect = new Win32Interop.RECT();
+                Win32Interop.GetWindowRect(hwnd, out rect);
+
+                var zOrder = Win32Interop.GetWindowZOrder(hwnd);
+                var location = new System.Drawing.Rectangle(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
+
+                saveInfo.Add(createSaveInfo(tool, location, zOrder));
+            }
+
+            return saveInfo;
+        }
+
+        public static async Task<List<ToolLaunchInfo>> LaunchToolsFromSavedLayout(List<ToolSaveInfo> saveInfo, bool slowMode)
+        {
+            CloseTools();
+            var launchInfo = new List<ToolLaunchInfo>();
+            foreach (var toolSaveInfo in saveInfo)
+            {
+                if(toolSaveInfo.ToolType == ToolType.CpuZ)
+                {
+                    var cpuzSaveInfo = (CpuzSaveInfo)toolSaveInfo;
+                    launchInfo.Add(new CpuzLaunchInfo
+                    {
+                        TabType = cpuzSaveInfo.TabType,
+                        SpdSlot = cpuzSaveInfo.SpdSlot,
+                        IsCustomLayout = true,
+                        Location = cpuzSaveInfo.Location,
+                        ZOrder = cpuzSaveInfo.ZOrder
+                    });
+                }
+                else
+                {
+                    launchInfo.Add(new ToolLaunchInfo
+                    {
+                        IsCustomLayout = true,
+                        ToolType = toolSaveInfo.ToolType,
+                        Location = toolSaveInfo.Location,
+                        ZOrder = toolSaveInfo.ZOrder
+                    });
+                }
+            }
+
+            await LaunchTools(launchInfo, slowMode);
+            return _openTools;
         }
     }
 }

--- a/EhwValidationTool/ToolLauncher.cs
+++ b/EhwValidationTool/ToolLauncher.cs
@@ -134,6 +134,14 @@ namespace EhwValidationTool
                         if (tabHandle != IntPtr.Zero)
                         {
                             Win32Interop.SelectTabByIndex(tabHandle, launchInfo.SelectTabIndex.Value);
+
+                            var cpuzLaunchInfo = launchInfo as CpuzLaunchInfo;
+                            if (cpuzLaunchInfo != null && cpuzLaunchInfo.TabType == CpuzLaunchInfo.CpuzTabType.SPD && cpuzLaunchInfo.SpdSlot.HasValue)
+                            {
+                                var tabPageHwnd = Win32Interop.GetTabHwndByIndex(tabHandle, launchInfo.SelectTabIndex.Value);
+                                var comboboxHwnd = Win32Interop.GetFirstComboBoxControl(tabPageHwnd);
+                                Win32Interop.SelectComboBoxValueByIndex(comboboxHwnd, cpuzLaunchInfo.SpdSlot.Value-1);
+                            }
                         }
                     }
 

--- a/EhwValidationTool/ToolSaveInfo.cs
+++ b/EhwValidationTool/ToolSaveInfo.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+
+namespace EhwValidationTool
+{
+    [JsonConverter(typeof(ToolSaveInfoConverter))]
+    public class ToolSaveInfo
+    {
+        public virtual ToolType ToolType {  get; set; }
+        public Rectangle Location { get; set; }
+        public int ZOrder { get; set; }
+    }
+}

--- a/EhwValidationTool/ToolSaveInfoConverter.cs
+++ b/EhwValidationTool/ToolSaveInfoConverter.cs
@@ -1,0 +1,58 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Windows.Forms;
+
+namespace EhwValidationTool
+{
+    public class ToolSaveInfoConverter : JsonConverter
+    {
+        private ToolSaveInfo Create(Type objectType, JObject jObject)
+        {
+            ToolType toolType = default;
+            var toolTypeName = jObject.Value<string>("ToolType");
+            if (!String.IsNullOrWhiteSpace(toolTypeName) && Enum.IsDefined(typeof(ToolType), toolTypeName))
+            {
+                // 4/25/16 sag: a new property was added to disambiguate what type of column we need to create.  the property
+                // exists and has a value that is defined by the LiveQueryColumnType enum.  lets set the type of column to create
+                toolType = (ToolType)Enum.Parse(typeof(ToolType), toolTypeName);
+            }
+
+            switch (toolType)
+            {
+                case ToolType.CpuZ:
+                    return new CpuzSaveInfo();
+                default:
+                    return new ToolSaveInfo();
+            }
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException("Unnecessary because CanWrite is false. The type will skip the converter.");
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            // Load JObject from stream 
+            JObject jObject = JObject.Load(reader);
+
+            // Create target object based on JObject 
+            var target = Create(objectType, jObject);
+
+            // Populate the object properties 
+            serializer.Populate(jObject.CreateReader(), target);
+
+            return target;
+        }
+        public override bool CanWrite
+        {
+            get { return false; }
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(ToolSaveInfo).IsAssignableFrom(objectType);
+        }
+    }
+}

--- a/EhwValidationTool/Win32Interop.cs
+++ b/EhwValidationTool/Win32Interop.cs
@@ -153,6 +153,9 @@ namespace EhwValidationTool
 
         public const UInt32 TCM_FIRST = 0x1300;
         public const UInt32 TCM_SETCURFOCUS = (TCM_FIRST + 48);
+        public const UInt32 CB_SETCURSEL = 0x014E;
+        public const Int32 VK_DOWN = 0x28;
+        public const UInt32 WM_KEYDOWN = 0x0100;
 
 
         [DllImport("user32.dll", EntryPoint = "SendMessage", CharSet = CharSet.Auto)]
@@ -172,6 +175,28 @@ namespace EhwValidationTool
             return pszType.ToString();
         }
 
+        public static IntPtr GetFirstComboBoxControl(IntPtr hwnd)
+        {
+            var windows = GetChildWindows(hwnd);
+            foreach (var window in windows)
+            {
+                var classNN = RealGetWindowClassM(window);
+                if (classNN.StartsWith("ComboBox"))
+                {
+                    return window;
+                }
+            }
+
+            return IntPtr.Zero;
+        }
+        public static void SelectComboBoxValueByIndex(IntPtr comboboxHandle, int selectedIndex)
+        {
+            SendMessage(comboboxHandle, CB_SETCURSEL, 0, null);
+            for (int i = 0; i < selectedIndex; i++)
+                SendMessage(comboboxHandle, WM_KEYDOWN, VK_DOWN, null);
+        }
+
+
         public static IntPtr GetFirstTabControl(IntPtr hwnd)
         {
             var windows = GetChildWindows(hwnd);
@@ -186,6 +211,24 @@ namespace EhwValidationTool
             }
 
             return tabList.OrderBy(c => c.depthFromRootWindow).Select(c => c.hwnd).First();
+        }
+
+        // assumes hwnd is a SysTabControl
+        public static IntPtr GetTabHwndByIndex(IntPtr hwnd, int tabIndex)
+        {
+            var windows = GetChildWindows(hwnd);
+
+            foreach (var window in windows)
+            {
+                var classNN = RealGetWindowClassM(window);
+                if (string.Equals(classNN, "#32770"))
+                    tabIndex--;
+
+                if (tabIndex < 0)
+                    return window;
+            }
+
+            return IntPtr.Zero;
         }
 
         public static void SelectTabByIndex(IntPtr tabControlHandle, int tabIndex)

--- a/EhwValidationTool/Win32Interop.cs
+++ b/EhwValidationTool/Win32Interop.cs
@@ -153,9 +153,10 @@ namespace EhwValidationTool
 
         public const UInt32 TCM_FIRST = 0x1300;
         public const UInt32 TCM_SETCURFOCUS = (TCM_FIRST + 48);
-        public const UInt32 CB_SETCURSEL = 0x014E;
-        public const Int32 VK_DOWN = 0x28;
-        public const UInt32 WM_KEYDOWN = 0x0100;
+        public const UInt32 CB_SETCURSEL = 0x014E; 
+        public const UInt32 WM_COMMAND = 0x0111;       // Windows message for commands
+        public const UInt32 CBN_SELCHANGE = 1;         // Notification for combobox selection change
+
 
 
         [DllImport("user32.dll", EntryPoint = "SendMessage", CharSet = CharSet.Auto)]
@@ -189,11 +190,12 @@ namespace EhwValidationTool
 
             return IntPtr.Zero;
         }
+
+
         public static void SelectComboBoxValueByIndex(IntPtr comboboxHandle, int selectedIndex)
         {
-            SendMessage(comboboxHandle, CB_SETCURSEL, 0, null);
-            for (int i = 0; i < selectedIndex; i++)
-                SendMessage(comboboxHandle, WM_KEYDOWN, VK_DOWN, null);
+            SendMessage(comboboxHandle, CB_SETCURSEL, selectedIndex, null);
+            SendMessage(GetParent(comboboxHandle), (int)WM_COMMAND, MAKEWPARAM(GetDlgCtrlID(comboboxHandle), (int)CBN_SELCHANGE), (int)comboboxHandle);
         }
 
 
@@ -235,6 +237,11 @@ namespace EhwValidationTool
         {
             SendMessage(tabControlHandle, TCM_SETCURFOCUS, tabIndex, null);
         }
+        public static int MAKEWPARAM(int low, int high)
+        {
+            return (low & 0xFFFF) | ((high & 0xFFFF) << 16);
+        }
+
 
 
         public const int WM_NCLBUTTONDOWN = 0xA1;
@@ -244,5 +251,8 @@ namespace EhwValidationTool
         public static extern int SendMessage(IntPtr hWnd, int Msg, int wParam, int lParam);
         [System.Runtime.InteropServices.DllImport("user32.dll")]
         public static extern bool ReleaseCapture();
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern int GetDlgCtrlID(IntPtr hWnd);
     }
 }


### PR DESCRIPTION
Added the ability to optionally launch 2 new CPU-Z windows to show the SPD tab and select either slots 1&2 or 2&4.

Also added the ability to save the layout of the open tools.  The saved layout can be launched at a later time to place each tool in the previous location.  An attempt is made to restore the correct z-order (layering of windows on top of each other), but some versions of Windows prevent this attempt.